### PR TITLE
[update] tty_setting

### DIFF
--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -3,4 +3,3 @@ services:
   python_dev_env:
     build:
       dockerfile: .devcontainer/Dockerfile_devcontainer.dockerfile
-    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ${USERPROFILE-~}/.ssh:/home/vscode/.ssh
     image: python_dev_env-image
     container_name: python_dev_env-container
+    tty: true
     env_file: .env # shellスクリプト内でも環境変数として使用するため
 
   db: # PostgreSQLクライントからの接続の際のhostnameはこの'db'を使う


### PR DESCRIPTION
起動し続けるために `command: /bin/sh -c "while sleep 1000; do :; done"` としていたが、docker compose側で `tty: true` を使用すればよいだけなので修正。