### PR TITLE
[update] library

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,9 @@
 # lint
-flake8==3.8.2
-black==19.10b0
+flake8==3.8.4
+black==20.8b1
 flake8-docstrings==1.5.0
 flake8-quotes==3.2.0
 
 # test
-pytest==5.4.3
-pytest-cov==2.9.0
-parameterized==0.7.4
+pytest==6.1.0
+pytest-cov==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # sample
-psycopg2==2.8.5
+psycopg2==2.8.6


### PR DESCRIPTION
既存のライブラリを最新版にアップデート
parameterizedについてはpytest自体に `pytest.mark.parametrize` を持っているのでこちらを使う想定で除去した。

https://docs.pytest.org/en/stable/parametrize.html
